### PR TITLE
Fixed watermark handling

### DIFF
--- a/library/src/main/java/org/apache/apex/malhar/lib/window/impl/WindowedJoinOperatorFeatures.java
+++ b/library/src/main/java/org/apache/apex/malhar/lib/window/impl/WindowedJoinOperatorFeatures.java
@@ -61,14 +61,14 @@ abstract class WindowedJoinOperatorFeatures<InputT1, InputT2, AccumT, Accumulati
     latestWatermark1 = watermark.getTimestamp();
     // Select the smallest timestamp of the latest watermarks as the watermark of the operator.
     long minWatermark = Math.min(latestWatermark1, latestWatermark2);
-    operator.setCurrentWatermark(minWatermark);
+    operator.setNextWatermark(minWatermark);
   }
 
   void processWatermark2(ControlTuple.Watermark watermark)
   {
     latestWatermark2 = watermark.getTimestamp();
     long minWatermark = Math.min(latestWatermark1, latestWatermark2);
-    operator.setCurrentWatermark(minWatermark);
+    operator.setNextWatermark(minWatermark);
   }
 
   /**

--- a/library/src/test/java/org/apache/apex/malhar/lib/window/impl/WindowedJoinOperatorTest.java
+++ b/library/src/test/java/org/apache/apex/malhar/lib/window/impl/WindowedJoinOperatorTest.java
@@ -129,8 +129,8 @@ public class WindowedJoinOperatorTest
 
     // Current watermark of join operator could only change during endWindow() event.
     op.controlInput.process(new WatermarkImpl(1100000));
-    Assert.assertEquals(1100000, op.currentWatermark);
     op.endWindow();
+    Assert.assertEquals(1100000, op.currentWatermark);
     Assert.assertEquals(3, sink.collectedTuples.size());
 
     // If the upstreams sent a watermark but the minimum of the latest input watermarks doesn't change, the join


### PR DESCRIPTION
The reason for this change is that we cannot change the state of the watermark in the middle of an apex streaming window because otherwise it would break idempotency.
